### PR TITLE
[CMP-1298] Adding Django DEBUG flag to Helm ENV variables

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
+           - name: DEBUG
+             value: {{ quote .Values.DEBUG }}
            - name: OCP_IP
              value: {{ quote .Values.OCP_IP }}
            - name: OCP_PORT

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 
+DEBUG: ""
 IMAGE_VERSION: ""
 OCP_IP: ""
 OCP_PORT: ""


### PR DESCRIPTION
JIRA - [CMP-1298](https://cloudbolt.atlassian.net/browse/CMP-1298)
#### Adding Django DEBUG flag to Helm ENV variable

This pull request adds the DEBUG flag from settings.py file of Django project to Helm deployment.yaml file. This will give us freedom to pass that variable in order to show/hide the debug logs of Django application in console.

[CMP-1298]: https://cloudbolt.atlassian.net/browse/CMP-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ