### PR TITLE
[CMP-1298] Correcting wrong secret name mentioned in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ oc create secret generic my-ocp-secret --from-literal=OCP_SERVICEPASS=<ocp-passw
 ```
 To create a secret for Ingestion API token required for API, run below command
 ```console
-oc create secret generic my-ocp-secret --from-literal=INGESTION_API_TOKEN=<ingestion-api-token> -n cloudbolt-collector
+oc create secret generic cb-ingestion-token --from-literal=INGESTION_API_TOKEN=<ingestion-api-token> -n cloudbolt-collector
 ```
 To install the chart with the environmental variables:
 


### PR DESCRIPTION
JIRA - [CMP-1298](https://cloudbolt.atlassian.net/browse/CMP-1298)
#### Correcting wrongly added secret in command in README.md file

This pull request corrects the wrongly added name of the secret for storing bearer token of ingestion API.

[CMP-1298]: https://cloudbolt.atlassian.net/browse/CMP-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ