### PR TITLE
[CMP-1298] Add jira ticket check with warning to PR

### DIFF
--- a/.github/workflows/jira-check.yml
+++ b/.github/workflows/jira-check.yml
@@ -1,0 +1,28 @@
+name: PR Title Jira Ticket Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+jobs:
+  check-pr-title:
+    name: Ensure Jira Ticket
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Check PR title for Jira Ticket
+      run: |
+        PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
+        if ! [[ "$PR_TITLE" =~ CMP-[0-9]+ ]]; then
+          echo "Please change the PR title to '[CMP-xxxx] $PR_TITLE' to indicate the jira ticket the PR is associated with." >> $GITHUB_STEP_SUMMARY
+          echo "## :error: Error in PR Title" >> $GITHUB_STEP_SUMMARY
+          echo "The PR title does not follow the required format '[CMP-xxxx] Title'. Please update the title to include the associated JIRA ticket." >> $GITHUB_STEP_SUMMARY
+          exit 1
+        fi
+      env:
+        GITHUB_EVENT_PATH: ${{ github.event_path }}


### PR DESCRIPTION
#### Introduction of Jira Ticket Check in PR Titles

This pull request introduces a new GitHub Actions workflow named "PR Title Jira Ticket Check" to automate the verification of PR titles against a defined naming convention. The goal is to ensure that each PR title includes a JIRA ticket reference, facilitating better tracking and management of project tasks.

#### Workflow Details (`jira-check.yml`):

1. **Workflow Trigger**:
   - The workflow is triggered on `pull_request` events, specifically when a pull request is opened, edited, reopened, or synchronized.

2. **Job Configuration**:
   - The job is named `Ensure Jira Ticket`.
   - It runs on the `ubuntu-latest` GitHub Actions runner.

3. **Workflow Steps**:
   - **Check out code**: Utilizes `actions/checkout@v4` to check out the code.
   - **Check PR Title for Jira Ticket**:
     - Extracts the PR title using `jq` from the GitHub event JSON.
     - Checks if the PR title matches the required format (i.e., contains `CMP-[0-9]+`).
     - If the PR title does not comply, it appends an error message to the `GITHUB_STEP_SUMMARY`. This message instructs the PR creator to format the title correctly, for example, `[CMP-xxxx] Title`, where `xxxx` is the JIRA ticket number.
     - The step fails (`exit 1`) if the PR title does not follow the required format, effectively blocking the PR from proceeding until the title is corrected.

#### Summary

The introduction of this workflow is a significant step towards standardizing PR titles and ensuring consistent references to JIRA tickets. It automates the process of checking PR titles, thereby reducing manual oversight and improving the efficiency of PR handling. The requirement for JIRA ticket references in PR titles is crucial for maintaining an organized and traceable link between code changes and project tasks or bug reports.