### PR TITLE
[CMP-1299] Fix syntax error in action.yml

### DIFF
--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -89,4 +89,3 @@ runs:
         echo "Chart Version: ${{ inputs.chart_version }}"
         echo "Image Tag: ${{ inputs.image_tag }}"
         echo "Latest Release: ${{ inputs.latest }}"
-{


### PR DESCRIPTION
The extra closing brace was causing a syntax error in the GitHub Actions workflow. This fix ensures the workflow runs as expected without any syntax issues.