### PR TITLE
[CMP-1299] Fix github repository variable for publish

### DIFF
--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -77,6 +77,7 @@ runs:
         pages_branch: gh-pages
       env:
         CR_TOKEN: ${{ inputs.github_token }}
+        GITHUB_REPOSITORY: cloudboltsoftware/cloudbolt-collector-helm
 
     - name: Output results
       shell: bash


### PR DESCRIPTION
The GITHUB_REPOSITORY environment variable was added to the release-helm-chart action to specify the repository where the Helm chart is located. This change allows the action to target the correct repository when releasing the Helm chart.