### PR TITLE
[CMP-1299] do not call cr --version

### DIFF
--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -68,12 +68,11 @@ runs:
         mkdir -p ./.cr-release-packages
 
     - name: Install Chart Releaser
+      shell: bash
       run: |
         curl -L https://github.com/helm/chart-releaser/releases/download/v1.6.1/chart-releaser_1.6.1_linux_amd64.tar.gz -o chart-releaser.tar.gz
         tar -zxvf chart-releaser.tar.gz
         sudo mv cr /usr/local/bin/
-        cr --version
-      shell: bash
 
     - name: Package Helm Chart
       shell: bash


### PR DESCRIPTION
The 'cr --version' command was removed from the Install Chart Releaser step in the GitHub action for releasing Helm charts. This command was redundant as it was only used for debugging purposes and does not affect the functionality of the action. Removing it simplifies the action and reduces unnecessary output in the action logs.