### PR TITLE
[CMP-1299] don't make duplicate pr

### DIFF
--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -54,13 +54,13 @@ runs:
       run: |
         git add Chart.yaml values.yaml
         git commit -m "Create release for version ${{ inputs.chart_version }}, appVersion ${{ inputs.app_version }}, and image tag ${{ inputs.image_tag }}"
-        git push --set-upstream origin ${{ steps.branch.outputs.branch }}
-        gh pr create \
-          --title "Update Helm Chart to version ${{ inputs.chart_version }}" \
-          --body "Updating appVersion to ${{ inputs.app_version }} and image tag to ${{ inputs.image_tag }}." \
-          --base main \
-          --repo CloudBoltSoftware/cloudbolt-collector-helm \
-          --head ${{ steps.branch.outputs.branch }}
+        # git push --set-upstream origin ${{ steps.branch.outputs.branch }}
+        # gh pr create \
+          # --title "Update Helm Chart to version ${{ inputs.chart_version }}" \
+          # --body "Updating appVersion to ${{ inputs.app_version }} and image tag to ${{ inputs.image_tag }}." \
+          # --base main \
+          # --repo CloudBoltSoftware/cloudbolt-collector-helm \
+          # --head ${{ steps.branch.outputs.branch }}
 
     - name: Make .cr-release-packages directory
       shell: bash


### PR DESCRIPTION
The git push and gh pr create commands are commented out to prevent automatic pushing and PR creation. This change is done to allow for manual review and approval of changes before they are pushed and a PR is created. This ensures that only verified and approved changes are pushed to the repository, enhancing the code quality and reducing the risk of introducing bugs.