### PR TITLE
[CMP-1299] use push instead of pr

### DIFF
--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -93,7 +93,9 @@ runs:
         --token $GITHUB_TOKEN \
         --generate-release-notes \
         --release-name-template "${{ inputs.chart_version }}" \
-        --package-path ./.cr-release-packages
+        --package-path ./.cr-release-packages \
+        --pages-branch gh-pages \
+        --push
         echo "Updating index.yaml"
         cr index \
         --config .cr.yaml \


### PR DESCRIPTION
The changes were made to specify the branch where the Helm chart packages will be published and to ensure that the packages are pushed to the repository. This will help in automating the release process of Helm charts and make it more efficient.