### PR TITLE
[CMP-1299] Add docs/ to .helmignore to prevent help from packaging docs folder

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# add docs folder
+docs/


### PR DESCRIPTION
* Adds docs/ to .hemlignore file to prevent repackaging