### PR TITLE
[CMP-1299] downgrade to secring.gpg

### DIFF
--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -77,7 +77,7 @@ runs:
     - name: Import PGP Key
       shell: bash
       run: |
-        echo "${{ inputs.pgp_private_key }}" | base64 --decode | gpg --import
+        echo "${{ inputs.pgp_private_key }}" | base64 --decode | gpg --batch --import --pinentry-mode loopback ${{ inputs.pgp_passphrase }}
 
     - name: Package Helm Chart
       shell: bash

--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -75,8 +75,8 @@ runs:
         version: v3.12.1
 
     - name: Import PGP Key
-      bash: shell
-      rum: |
+      shell: bash
+      run: |
         echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode | gpg --import
 
     - name: Package Helm Chart

--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -83,7 +83,7 @@ runs:
     - name: Package Helm Chart
       shell: bash
       run: >
-        echo "${{ inputs.pgp_passphrase }}" | helm package \
+        echo "${{ inputs.pgp_passphrase }}" |
         helm package
         --version ${{ inputs.chart_version }}
         --app-version ${{ inputs.app_version }}

--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -29,6 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Helm
+      shell: bash
       run: |
         curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
         chmod 700 get_helm.sh
@@ -69,9 +70,9 @@ runs:
         git push --set-upstream origin ${{ steps.branch.outputs.branch }}
 
     - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.1
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.12.1
 
     - name: Import PGP Key
       bash: shell
@@ -129,19 +130,19 @@ runs:
         --body "Release ${{ inputs.chart_version }}"
         --base main
         --head ${{ steps.branch.outputs.branch }}
+        --repo CloudBoltSoftware/cloudbolt-collector-helm
 
 
     - name: Output results
       shell: bash
       run: |
-        echo "| Key            | Value |"
-        echo "|----------------|-------|"
-        echo "| New Branch     | $NEW_BRANCH |"
-        echo "| App Version    | ${{ inputs.app_version }} |"
-        echo "| Chart Version  | ${{ inputs.chart_version }} |"
-        echo "| Image Tag      | ${{ inputs.image_tag }} |"
-        echo "| Latest Release | ${{ inputs.latest }} |"
-        echo "| Package URL    | [Link](https://cloudboltsoftware.github.io/cloudbolt-collector-helm/cloudbolt-collector-${{ inputs.chart_version }}.tgz) |"
-        echo "| Docs URL       | [Link](https://cloudboltsoftware.github.io/cloudbolt-collector-helm/) |"
-        echo "| Release URL    | [Link](https://github.com/CloudBoltSoftware/cloudbolt-collector-helm/releases/tag/${{ inputs.chart_version }}) |"
-        echo "| Public Key    | [Link](https://cloudboltsoftware.github.io/cloudbolt-collector-helm/public.key) |"
+        echo "| Key            | Value |" >> $GITHUB_STEP_SUMMARY
+        echo "|----------------|-------|" >> $GITHUB_STEP_SUMMARY
+        echo "| New Branch     | $NEW_BRANCH |"  >> $GITHUB_STEP_SUMMARY
+        echo "| App Version    | ${{ inputs.app_version }} |"  >> $GITHUB_STEP_SUMMARY
+        echo "| Chart Version  | ${{ inputs.chart_version }} |"  >> $GITHUB_STEP_SUMMARY
+        echo "| Image Tag      | ${{ inputs.image_tag }} |"  >> $GITHUB_STEP_SUMMARY
+        echo "| Latest Release | ${{ inputs.latest }} |"  >> $GITHUB_STEP_SUMMARY
+        echo "| Package URL    | [Link](https://cloudboltsoftware.github.io/cloudbolt-collector-helm/cloudbolt-collector-${{ inputs.chart_version }}.tgz) |"  >> $GITHUB_STEP_SUMMARY
+        echo "| Docs URL       | [Link](https://cloudboltsoftware.github.io/cloudbolt-collector-helm/) |"  >> $GITHUB_STEP_SUMMARY
+        echo "| Release URL    | [Link](https://github.com/CloudBoltSoftware/cloudbolt-collector-helm/releases/tag/${{ inputs.chart_version }}) |"  >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -88,9 +88,9 @@ runs:
         --version ${{ inputs.chart_version }}
         --app-version ${{ inputs.app_version }}
         --destination ./docs
-        --sign  \
-        --key 'CloudBolt Software Inc' \
-        --passphrase-file - \
+        --sign
+        --key 'CloudBolt Software Inc'
+        --passphrase-file -
         .
 
     - name: Update Helm Repo Index

--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -80,6 +80,13 @@ runs:
         gpg_private_key: ${{ inputs.pgp_private_key }}
         passphrase: ${{ inputs.pgp_passphrase }}
 
+    - name: Downgrade GPG to secring.pgp
+      shell: bash
+      run: |
+        mkdir -p ~/.gnupg
+        gpg --export >~/.gnupg/pubring.gpg
+        gpg --export-secret-keys >~/.gnupg/secring.gpg
+
     - name: Package Helm Chart
       shell: bash
       run: >

--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -77,7 +77,7 @@ runs:
     - name: Import PGP Key
       shell: bash
       run: |
-        echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode | gpg --import
+        echo "${{ inputs.pgp_private_key }}" | base64 --decode | gpg --import
 
     - name: Package Helm Chart
       shell: bash

--- a/.github/actions/release-helm-chart/action.yml
+++ b/.github/actions/release-helm-chart/action.yml
@@ -74,10 +74,11 @@ runs:
       with:
         version: v3.12.1
 
-    - name: Import PGP Key
-      shell: bash
-      run: |
-        echo "${{ inputs.pgp_private_key }}" | base64 --decode | gpg --batch --import --pinentry-mode loopback ${{ inputs.pgp_passphrase }}
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ inputs.pgp_private_key }}
+        passphrase: ${{ inputs.pgp_passphrase }}
 
     - name: Package Helm Chart
       shell: bash


### PR DESCRIPTION
- 🔧 chore(release-helm-chart): add step to downgrade GPG to secring.pgp The GPG version used in the GitHub action was causing compatibility issues. To resolve this, a step was added to downgrade GPG to secring.pgp. This ensures that the GPG version used is compatible with the rest of the workflow.
