### PR TITLE
[CMP-1410] Handling SSL verification issue with some image version optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Below is a table of various parameters that can be set in the `values.yaml` file
 |------------------------------------|------------|--------------------------------------|---------------------|
 | `DEBUG`                            | No         | Debug mode flag                      | `""` (empty string) |
 | `IMAGE_VERSION`                    | No         | Version of the image                 | `"<helm-chart-version>"`|
-| `OCP_ENABLE_SSL_VERIFICATION`      | No         | SSL Verification for HTTP and HTTPS  | `""` (empty string) |
 | `INGESTION_API_URL`                | Yes        | Ingestion API URL                    | `""` (empty string) |
 | `SERVICE_ACCOUNT_NAME`             | Yes        | OpenShift ServiceAccountName         | `""` (empty string) |
 
@@ -105,7 +104,6 @@ Replace `<placeholders>` with appropriate values:
 
 ```console
 export IMAGE_VERSION="<release-version>"  # Default is chart version
-export OCP_ENABLE_SSL_VERIFICATION="<SSL Verification for http and https>"
 export INGESTION_API_URL="<ingestion-api-url>"
 export SERVICE_ACCOUNT_NAME="<service-account-name>"
 ```
@@ -126,7 +124,6 @@ If you want to install version `v0.20.0`, you can specify it using the `--versio
 
 ```console
 helm install cloudbolt-collector cloudbolt-collector/cloudbolt-collector \
-  --set OCP_ENABLE_SSL_VERIFICATION=$OCP_ENABLE_SSL_VERIFICATION \
   --set INGESTION_API_URL=$INGESTION_API_URL \
   --set SERVICE_ACCOUNT_NAME=$SERVICE_ACCOUNT_NAME
 ```
@@ -143,7 +140,6 @@ Then, upgrade the release to the desired version. If you want to upgrade to the 
 
 ```console
 helm upgrade cloudbolt-collector cloudbolt-collector/cloudbolt-collector \
-  --set OCP_ENABLE_SSL_VERIFICATION=$OCP_ENABLE_SSL_VERIFICATION \
   --set INGESTION_API_URL=$INGESTION_API_URL \
   --ser SERVICE_ACCOUNT_NAME=$SERVICE_ACCOUNT_NAME
 ```
@@ -154,7 +150,6 @@ If you wish to upgrade to a specific version, use the `--version` flag:
 helm upgrade cloudbolt-collector cloudbolt-collector/cloudbolt-collector \
   --version v0.21.0 \
   --set IMAGE_VERSION=$IMAGE_VERSION \
-  --set OCP_ENABLE_SSL_VERIFICATION=$OCP_ENABLE_SSL_VERIFICATION \
   --set INGESTION_API_URL=$INGESTION_API_URL \
   --set SERVICE_ACCOUNT_NAME=$SERVICE_ACCOUNT_NAME
 ```

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.IMAGE_VERSION | default .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.IMAGE_VERSION | default .Chart.Version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -42,11 +42,9 @@ spec:
               protocol: TCP
           env:
            - name: DEBUG
-             value: {{ quote .Values.DEBUG }}
-           - name: OCP_ENABLE_SSL_VERIFICATION
-             value: {{ quote .Values.OCP_ENABLE_SSL_VERIFICATION | default "False" }}
+             value: "{{ .Values.DEBUG }}"
            - name: INGESTION_API_URL
-             value: {{ quote .Values.INGESTION_API_URL }}
+             value: "{{ .Values.INGESTION_API_URL }}"
            - name: INGESTION_API_TOKEN
              valueFrom:
                secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -4,13 +4,11 @@
 replicaCount: 1
 DEBUG: ""
 IMAGE_VERSION: ""
-OCP_ENABLE_SSL_VERIFICATION: ""
 INGESTION_API_URL: ""
 SERVICE_ACCOUNT_NAME: ""
 image:
   repository: cloudboltsoftware/cloudbolt-collector
   pullPolicy: Always
-  tag: "v0.26.0"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
# Fix for SSL verification failure and some optimizations

## Overview
This pull request addresses the bug identified in the Jira ticket. As we have changed the API endpoints to call OpenShift from external to internal endpoint, Passing the SSL verify True is creating problem as it is unnecessary as we are calling the internal API endpoints. Also optimizations related to default tag/version to pull if IMAGE_VERSION not passed.

## Changes
1. **Removing support of OCP_ENABLE_SSL_VERIFICATION external value setting option**: We have removed the option to set value for OCP_ENABLE_SSL_VERIFICATION as we are calling internal API endpoints only. Hence not required.
2. **Setting default for tag/version of docker image**: We have added value from Chart.yaml where we are updating the version with every deployment.

## Impact
- The deployment will run without having SSL verification failed and will collect the data as expected.
- If user do not pass IMAGE_VERSION or  --version flag, then they will pull version from Chart.yaml as default.